### PR TITLE
Convert to fully-static site (with no search)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+# Settings in the [build] context are global and are applied to 
+# all contexts unless otherwise overridden by more specific contexts.
+[build]
+  publish = "_site/"
+  command = "python ./lib/render.py"
+
+[[plugins]]
+  # Installs the Lighthouse Build Plugin for all deploy contexts
+  package = "@netlify/plugin-lighthouse"


### PR DESCRIPTION
As part of making Parts Horse more sustainable long-term, I'm converting it to a fully-static site.

Most of this work was already done, for performance reasons. It's just a matter of cleaning it up and removing various now-unneeded configuration files.